### PR TITLE
replace normed -> density for plt.hist

### DIFF
--- a/cmnn_analysis.py
+++ b/cmnn_analysis.py
@@ -652,11 +652,11 @@ def make_hist_plots( verbose, runid ):
     pfnm = 'output/run_'+runid+'/analysis/hist_z'
     fig = plt.figure(figsize=(8,8))
     plt.rcParams.update({'font.size':20})
-    plt.hist( ztrain, normed=True,bins=100,histtype='step',ls='solid',\
+    plt.hist( ztrain, density=True,bins=100,histtype='step',ls='solid',\
             lw=2,alpha=0.5,color='grey',label='train z')
-    plt.hist( ztrue, normed=True,bins=100,histtype='step',ls='solid',\
+    plt.hist( ztrue, density=True,bins=100,histtype='step',ls='solid',\
             lw=2,alpha=0.7,color='blue',label='test z true')
-    plt.hist( zphot, normed=True,bins=100,histtype='step',ls='solid',\
+    plt.hist( zphot, density=True,bins=100,histtype='step',ls='solid',\
             lw=2,alpha=0.7,color='red',label='test photo-z')
     plt.xlabel('Redshift')
     plt.ylabel('Fraction of Galaxies')

--- a/cmnn_catalog.py
+++ b/cmnn_catalog.py
@@ -232,9 +232,9 @@ def make_plots(verbose, runid):
     pfnm = 'output/run_'+runid+'/plot_cats/hist_ztrue'
     fig  = plt.figure(figsize=(10,7))
     plt.rcParams.update({'font.size':20})
-    plt.hist( test_tz,  normed=True,bins=30,histtype='step',ls='solid',lw=2,alpha=1,  \
+    plt.hist( test_tz,  density=True,bins=30,histtype='step',ls='solid',lw=2,alpha=1,  \
         color='black',label='test')
-    plt.hist( train_tz, normed=True,bins=30,histtype='step',ls='solid',lw=4,alpha=0.5,\
+    plt.hist( train_tz, density=True,bins=30,histtype='step',ls='solid',lw=4,alpha=0.5,\
         color='black',label='train')
     plt.xlabel('True Catalog Redshift')
     plt.ylabel('Fraction of Galaxies')
@@ -250,11 +250,11 @@ def make_plots(verbose, runid):
     filt_colors = ['darkviolet','darkgreen','red','darkorange','brown','black']
     for f in range(6):
         tex = np.where( np.isfinite(test_m[:,f]) )[0]
-        plt.hist( test_m[tex,f], normed=True,cumulative=True,bins=30,histtype='step',ls='solid',\
+        plt.hist( test_m[tex,f], density=True,cumulative=True,bins=30,histtype='step',ls='solid',\
             lw=2,alpha=1,  \
             color=filt_colors[f],label='test '+filt_names[f])
         trx = np.where( np.isfinite(train_m[:,f]) )[0]
-        plt.hist( train_m[trx,f], normed=True,cumulative=True,bins=30,histtype='step',ls='solid',\
+        plt.hist( train_m[trx,f], density=True,cumulative=True,bins=30,histtype='step',ls='solid',\
             lw=4,alpha=0.5,  \
             color=filt_colors[f],label='train '+filt_names[f])
         del tex,trx
@@ -273,10 +273,10 @@ def make_plots(verbose, runid):
     filt_colors = ['darkviolet','darkgreen','red','darkorange','brown','black']
     for f in range(6):
         tex = np.where( np.isfinite(test_m[:,f]) )[0]
-        plt.hist( test_me[tex,f], normed=True,bins=mebins,histtype='step',ls='solid',\
+        plt.hist( test_me[tex,f], density=True,bins=mebins,histtype='step',ls='solid',\
             lw=2,alpha=1,color=filt_colors[f],label='test '+filt_names[f])
         trx = np.where( np.isfinite(train_m[:,f]) )[0]
-        plt.hist( train_me[trx,f], normed=True,bins=mebins,histtype='step',ls='solid',\
+        plt.hist( train_me[trx,f], density=True,bins=mebins,histtype='step',ls='solid',\
             lw=4,alpha=0.5,color=filt_colors[f],label='train '+filt_names[f])
         del tex,trx
     plt.xlabel('Apparent Magnitude Error')


### PR DESCRIPTION
This PR addresses issue #16, the only change is replacing the deprecated `normed=True` with `density=True` in instances of plt.hist.  Functionality for the two keywords is unchanged, but normed now throws an error for newer versions of matplotlib, and density has the additional benefit of properly normalizing histograms even for uneven bin spacings.  